### PR TITLE
fix: Do not set severity to error for 4xx codes

### DIFF
--- a/aws.go
+++ b/aws.go
@@ -79,7 +79,7 @@ func (h *awsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if sw.Status() > 399 && maxLevel < slog.LevelError {
+	if sw.Status() > 499 && maxLevel < slog.LevelError {
 		maxLevel = slog.LevelError
 	}
 

--- a/aws.go
+++ b/aws.go
@@ -208,6 +208,11 @@ func (l *awsLogger) WithAttributes() attributer {
 	return &awsAttributer{logger: l, attributes: attrs}
 }
 
+// TraceID returns the trace ID of the request logs
+func (l *awsLogger) TraceID() string {
+	return l.traceID
+}
+
 func (l *awsLogger) log(ctx context.Context, level slog.Level, message string) {
 	l.root.mu.Lock()
 	if l.root.maxLevel < level {

--- a/aws_test.go
+++ b/aws_test.go
@@ -470,6 +470,10 @@ func Test_awsLogger(t *testing.T) {
 			l.Errorf(ctx, tt.args.format, tt.args.v...)
 			verifyLog(buf.String(), "Errorf", tt.wantErrorf, slog.LevelError)
 			buf.Reset()
+
+			if l.TraceID() != tt.fields.traceID {
+				t.Errorf("awsLogger.TraceID() = %v, want %v", l.TraceID(), tt.fields.traceID)
+			}
 		})
 	}
 }

--- a/console.go
+++ b/console.go
@@ -190,6 +190,11 @@ func (l *consoleLogger) WithAttributes() attributer {
 	return &consoleAttributer{logger: l, attributes: attrs}
 }
 
+// TraceID returns an empty string for the console logger
+func (l *consoleLogger) TraceID() string {
+	return ""
+}
+
 func (l *consoleLogger) console(level logging.Severity, c color, msg string) {
 	for k, v := range l.attributes {
 		msg += fmt.Sprintf(", %s=%v", k, v)

--- a/console.go
+++ b/console.go
@@ -75,7 +75,7 @@ func (c *consoleHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	l.mu.Unlock()
 
 	// status code should also set the minimum maxSeverity to Error
-	if sw.Status() > 399 && maxSeverity < logging.Error {
+	if sw.Status() > 499 && maxSeverity < logging.Error {
 		maxSeverity = logging.Error
 	}
 

--- a/console.go
+++ b/console.go
@@ -105,7 +105,7 @@ func newConsoleLogger(r *http.Request, noColor bool) *consoleLogger {
 	l := &consoleLogger{
 		r: r, noColor: noColor,
 		rsvdReqKeys:   []string{cslReqSize, cslRespSize, cslLogCount},
-		maxSeverity:   logging.Debug,
+		maxSeverity:   logging.Info,
 		reqAttributes: make(map[string]any),
 		attributes:    make(map[string]any),
 	}

--- a/console_test.go
+++ b/console_test.go
@@ -254,7 +254,7 @@ func TestNewConsoleLogger(t *testing.T) {
 			want: &consoleLogger{
 				r:             &http.Request{},
 				noColor:       true,
-				maxSeverity:   logging.Debug,
+				maxSeverity:   logging.Info,
 				rsvdReqKeys:   []string{"requestSize", "responseSize", "logCount"},
 				reqAttributes: map[string]any{},
 				attributes:    map[string]any{},

--- a/context.go
+++ b/context.go
@@ -65,6 +65,9 @@ type ctxLogger interface {
 
 	// WithAttributes returns an attributer that can be used to add child (trace) log attributes
 	WithAttributes() attributer
+
+	// TraceID returns the trace ID of the request logs
+	TraceID() string
 }
 
 // attributer defines the interface for adding attributes for child (trace) logs

--- a/gcp.go
+++ b/gcp.go
@@ -85,7 +85,7 @@ func (g *gcpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// status code should also set the minimum maxSeverity to Error
-	if sw.Status() > 399 && maxSeverity < logging.Error {
+	if sw.Status() > 499 && maxSeverity < logging.Error {
 		maxSeverity = logging.Error
 	}
 

--- a/gcp.go
+++ b/gcp.go
@@ -232,6 +232,11 @@ func (l *gcpLogger) WithAttributes() attributer {
 	return &gcpAttributer{logger: l, attributes: attrs}
 }
 
+// TraceID returns the trace ID of the request logs
+func (l *gcpLogger) TraceID() string {
+	return l.traceID
+}
+
 func (l *gcpLogger) log(ctx context.Context, severity logging.Severity, msg any) {
 	l.root.mu.Lock()
 	if l.root.maxSeverity < severity {

--- a/gcp_test.go
+++ b/gcp_test.go
@@ -566,6 +566,10 @@ func Test_gcpLogger(t *testing.T) {
 			l.Errorf(ctx, tt.args.format, tt.args.v...)
 			verifyOutput(buf.String(), "Errorf", tt.wantErrorf, logging.Error)
 			buf.Reset()
+
+			if l.TraceID() != tt.fields.traceID {
+				t.Errorf("TraceID() = %v, want %v", l.TraceID(), tt.fields.traceID)
+			}
 		})
 	}
 }

--- a/logger.go
+++ b/logger.go
@@ -50,6 +50,11 @@ func Req(r *http.Request) *Logger {
 	}
 }
 
+// TraceID returns the trace ID of the request logs
+func (l *Logger) TraceID() string {
+	return l.lg.TraceID()
+}
+
 // Debug logs a debug message.
 func (l *Logger) Debug(v any) {
 	l.lg.Debug(l.ctx, v)

--- a/logger_test.go
+++ b/logger_test.go
@@ -335,3 +335,7 @@ func (l *testCtxLogger) AddRequestAttribute(_ string, _ any) {}
 func (l *testCtxLogger) WithAttributes() attributer {
 	return &Mockattributer{}
 }
+
+func (l *testCtxLogger) TraceID() string {
+	return "testTraceID"
+}

--- a/mock_context_test.go
+++ b/mock_context_test.go
@@ -138,6 +138,20 @@ func (mr *MockctxLoggerMockRecorder) Infof(ctx, format any, v ...any) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Infof", reflect.TypeOf((*MockctxLogger)(nil).Infof), varargs...)
 }
 
+// TraceID mocks base method.
+func (m *MockctxLogger) TraceID() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TraceID")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// TraceID indicates an expected call of TraceID.
+func (mr *MockctxLoggerMockRecorder) TraceID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TraceID", reflect.TypeOf((*MockctxLogger)(nil).TraceID))
+}
+
 // Warn mocks base method.
 func (m *MockctxLogger) Warn(ctx context.Context, v any) {
 	m.ctrl.T.Helper()

--- a/std.go
+++ b/std.go
@@ -69,6 +69,11 @@ func (l *stdErrLogger) WithAttributes() attributer {
 	return &stdAttributer{logger: l, attributes: attrs}
 }
 
+// TraceID returns an empty string for the std logger
+func (l *stdErrLogger) TraceID() string {
+	return ""
+}
+
 func (l *stdErrLogger) std(level, msg string) {
 	for k, v := range l.attributes {
 		msg += fmt.Sprintf(", %s=%v", k, v)


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
Fix: Change Severity Classification for 400 Status Codes from Error to Info (#34)

feat: Expose TraceID of the logger (#34)
END_COMMIT_OVERRIDE
